### PR TITLE
Fix req for Plex player clients to be available during auth.

### DIFF
--- a/lib/states/not-authed.js
+++ b/lib/states/not-authed.js
@@ -101,10 +101,21 @@ var setupIntent = function(request, response) {
             if (result === 'authorized') {
                 db.updateAuthToken(app.user, app.plex.pinAuth.token).then(function() {
                     app.user.setupDefaults(true).then(function() {
-                        response.say("Congratulations! I am now linked to your Plex account. To save you some time, I went ahead and made some " +
-                            "assumptions about which server and which player you want to use. For the server, I picked " + app.user.serverName +
-                            ". And for the player, I picked " + app.user.playerName + ". If you'd like to change this, simply say 'Alexa, ask " +
-                            "" + app.INVOCATION_NAME + " to change some settings.");
+                        var responseText = "Congratulations! I am now linked to your Plex account. To save you some time, I went ahead and made some " +
+                            "assumptions about which server and which player you want to use.";
+
+                        if (app.user.serverName) {
+                            responseText += " For the server, I picked " + app.user.serverName + "."
+                        }
+
+                        if (app.user.playerName) {
+                            responseText += " And for the player, I picked " + app.user.playerName + ".";
+                        }
+
+                        responseText += " If you'd like to change this, simply say 'Alexa, ask " +
+                            "" + app.INVOCATION_NAME + " to change some settings.";
+
+                        response.say(responseText);
                         return response.send();
                     });
                 }).catch(function(err) {

--- a/lib/user.js
+++ b/lib/user.js
@@ -131,7 +131,11 @@ var User = function(app, dbobject) {
 
     Object.defineProperty(this, 'playerName', {
         get: function() {
-            return context.dbobject.player.name;
+            if (context.dbobject.player) {
+                return context.dbobject.player.name;
+            } else {
+                return null;
+            }
         }
     });
 
@@ -199,10 +203,14 @@ User.prototype.setDefaultPlayer = function(forceReset) {
     if (!this.player || forceReset) {
         return plexutils.getPlayers(context._app)
             .then(function(players) {
-                return db.updateUserPlayer(context, players[0])
-                    .then(function() {
-                        return true;
-                    })
+                if (players && players.length) {
+                    return db.updateUserPlayer(context, players[0])
+                        .then(function() {
+                            return true;
+                        })
+                } else {
+                    return Q.resolve(true);
+                }
         })
     }
 


### PR DESCRIPTION
Fixes #48.

Previously, if no player clients were found during the setup process, the
authorization would fail and quit. Now, if no players are found, the
authorization process continues without saving a default player. This allows
things like checking what's On Deck and Recently Added to work without a default
player saved.